### PR TITLE
feat: mark late entries within grace period in attendance 

### DIFF
--- a/prompt_hr/prompt_hr/doctype/attendance_regularization/attendance_regularization.py
+++ b/prompt_hr/prompt_hr/doctype/attendance_regularization/attendance_regularization.py
@@ -4,13 +4,29 @@
 import frappe
 from frappe.model.document import Document
 from prompt_hr.py.utils import send_notification_email, is_user_reporting_manager_or_hr
-from frappe.utils import get_datetime, time_diff_in_hours
+from frappe.utils import get_datetime
 from prompt_hr.py.auto_mark_attendance import mark_attendance
+from frappe.utils import get_datetime, add_days
 
 
 class AttendanceRegularization(Document):
 	
 	def validate(self):
+		# ! VALIDATE IF THE EMPLOYEE IS ALLOWED TO RAISE REGULARIZATION FOR PAST DATES
+		if self.regularization_date or self.attendance:
+			attendance_regularization_limit = frappe.db.get_single_value("HR Settings", "custom_allowed_to_raise_regularizations_for_past_days_for_prompt")
+			if attendance_regularization_limit:
+				attendance_regularization_limit = int(attendance_regularization_limit)
+				if self.regularization_date:
+					limit_date = add_days(frappe.utils.getdate(), -attendance_regularization_limit)
+					if get_datetime(self.regularization_date).date() < limit_date:
+						frappe.throw(f"Attendance Regularization cannot be raised for past dates more than {attendance_regularization_limit} days.")
+
+				if self.attendance:
+					attendance_doc = frappe.get_doc("Attendance", self.attendance)
+					if attendance_doc.attendance_date < limit_date:
+						frappe.throw(f"Attendance Regularization cannot be raised for past dates more than {attendance_regularization_limit} days.")
+
 		
 		is_rh = is_user_reporting_manager_or_hr(user_id=frappe.session.user, requesting_employee_id=self.employee)
 		if is_rh:
@@ -83,6 +99,3 @@ class AttendanceRegularization(Document):
 												)
 					self.employee_notified = 1
 
-
-
-		

--- a/prompt_hr/public/js/payroll_entry.js
+++ b/prompt_hr/public/js/payroll_entry.js
@@ -21,6 +21,7 @@ frappe.ui.form.on("Payroll Entry", {
     refresh: (frm) => {
         // ? REMOVE AUTO BRANCH ADDITION DATA
         empty_branch_field_if_form_is_new(frm);
+        send_salary_slip(frm)
         frm.get_field('custom_lop_summary').grid.cannot_add_rows = true;
         frm.refresh_field('custom_lop_summary');
 
@@ -261,4 +262,20 @@ function set_lop_month_options_for_all_rows(frm) {
             month_field, "options", options.join("\n")
         );
     }
+}
+
+
+// ? FUNCTION TO ADD CUSTOM BUTTON FOR GENERATING AND SENDING SALARY SLIP PDF
+function send_salary_slip(frm) {
+    frm.add_custom_button(__('Generate Salary Slip PDF'), function() {
+        frappe.call({
+            method: 'prompt_hr.py.payroll_entry.send_salary_sleep_to_employee',
+            args: {
+                payroll_entry_id: frm.doc.name
+            },
+            callback: function(r) {
+                frappe.msgprint(__('Salary Slip PDF has been generated and sending to the employees will be sent shortly.'));
+            }
+        });
+    });
 }

--- a/prompt_hr/py/auto_mark_attendance.py
+++ b/prompt_hr/py/auto_mark_attendance.py
@@ -345,6 +345,7 @@ def attendance(employee_data, mark_attendance_date, str_mark_attendance_date, da
         
         late_entry = late_entry_and_apply_penalty.get("is_late_entry")
         apply_penalty = late_entry_and_apply_penalty.get("apply_penalty")
+        late_entry_with_grace_period = late_entry_and_apply_penalty.get("is_late_entry_with_grace_period")
         
         if not is_half_day:
             shift_end_datetime = get_datetime(out_datetime.date()) + shift_end_time
@@ -412,6 +413,7 @@ def attendance(employee_data, mark_attendance_date, str_mark_attendance_date, da
                     "late_entry": late_entry,
                     "early_exit": is_early_exit,
                     "custom_apply_penalty": apply_penalty,
+                    "custom_late_entry_with_grace_period": late_entry_with_grace_period,
                     "in_time" : in_datetime if in_type_emp_checkin or regularize_start_time else None,
                     "out_time" : out_datetime if out_type_emp_checkin or regularize_end_time else None,
                     "custom_checkin_time" : in_datetime if in_type_emp_checkin else None,
@@ -433,6 +435,7 @@ def attendance(employee_data, mark_attendance_date, str_mark_attendance_date, da
                     "working_hours": final_working_hours,
                     "custom_overtime": ot_duration,
                     "late_entry": late_entry,
+                    "custom_late_entry_with_grace_period": late_entry_with_grace_period,
                     "early_exit": is_early_exit,
                     "custom_apply_penalty": apply_penalty,
                     "in_time" : in_datetime if in_type_emp_checkin else None,
@@ -460,6 +463,7 @@ def attendance(employee_data, mark_attendance_date, str_mark_attendance_date, da
             working_hours=final_working_hours,
             custom_overtime = ot_duration,
             late_entry = late_entry,
+            custom_late_entry_with_grace_period =late_entry_with_grace_period,
             early_exit = is_early_exit,
             custom_apply_penalty = apply_penalty,
             shift = shift_type,
@@ -544,8 +548,8 @@ def is_late_entry(employee_in_datetime, shift_start_time, grace_time , is_half_d
         shift_start_datetime = shift_start_time
     time_diff = employee_in_datetime - shift_start_datetime
     late_minutes = int(time_diff.total_seconds() // 60)
-    
-    return {"is_late_entry": 1 if late_minutes > 0 else 0, "apply_penalty": 1 if late_minutes > grace_time else 0}
+    # ? ADD LATE MINUTES WITH GRACE TIME TO CHECK IF THE EMPLOYEE IS LATE ENTRY ONLY OR LATE ENTRY WITH PENALTY
+    return {"is_late_entry": 1 if late_minutes > grace_time else 0, "apply_penalty": 1 if late_minutes > grace_time else 0, "is_late_entry_with_grace_period": 1 if late_minutes > 0 else 0}
     
 
 def create_attendance(
@@ -557,6 +561,7 @@ def create_attendance(
     working_hours = 0.0,
     custom_overtime= 0.0,
     late_entry = 0,
+    custom_late_entry_with_grace_period = 0,
     early_exit = 0,
     custom_apply_penalty = 0,
     shift = '',
@@ -585,6 +590,7 @@ def create_attendance(
     attendance_doc.working_hours = working_hours
     attendance_doc.custom_overtime = custom_overtime
     attendance_doc.late_entry = late_entry
+    attendance_doc.custom_late_entry_with_grace_period = custom_late_entry_with_grace_period
     attendance_doc.early_exit = early_exit
     attendance_doc.custom_apply_penalty = custom_apply_penalty
     attendance_doc.shift = shift

--- a/prompt_hr/py/payroll_entry.py
+++ b/prompt_hr/py/payroll_entry.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 from frappe.utils.xlsxutils import make_xlsx, read_xlsx_file_from_attached_file
 from frappe.utils.response import build_response
 from frappe import _
+import traceback
 
 
 # ? ON UPDATE CONTROLLER METHOD
@@ -692,3 +693,50 @@ def import_adhoc_salary_details(payroll_entry_id, file_url):
     frappe.msgprint(_(message))
 
     return {"added": records_added}
+
+
+@frappe.whitelist()
+# * METHOD TO FETCH AND SEND SALARY SLEEP TO EMPLOYEE
+# ! prompt_hr.py.payroll_entry.send_salary_sleep_to_employee
+def send_salary_sleep_to_employee(payroll_entry_id):
+    try:
+        salary_slip_info_list = frappe.db.get_all("Salary Slip", {"docstatus": 1, "payroll_entry": payroll_entry_id}, ['name', 'employee'])
+        print(salary_slip_info_list)
+        print_format_info = frappe.db.get_all("Print Format Selection", {"parenttype":"HR Settings", "parentfield": "custom_print_format_table_prompt", "document": "Salary Slip"}, ["print_format_document", "letter_head"], limit=1)
+        print(print_format_info)
+        print_format_id = print_format_info[0].get("print_format_document") if print_format_info else None
+        letter_head = print_format_info[0].get("letter_head") if print_format_info else None
+
+        if salary_slip_info_list:
+            for salary_slip_info in salary_slip_info_list:
+                attachments = []
+                preferred_email = frappe.db.get_value("Employee", salary_slip_info.employee, "prefered_email")
+                if not preferred_email:
+                    preferred_email = frappe.db.get_value("Employee", salary_slip_info.employee, "user_id")
+                try:
+                    # ? GENERATE PDF USING FRAPPE'S BUILT-IN PDF GENERATION
+                    pdf_content = frappe.get_print(
+                        doctype="Salary Slip",
+                        name= salary_slip_info.name,
+                        print_format=print_format_id,
+                        letterhead=letter_head,
+                        as_pdf=True,
+                    )
+                    # ? CREATE ATTACHMENT DICTIONARY
+                    attachment_name = f"Salary Slip_{salary_slip_info.name}_{print_format_id}.pdf"
+                    attachments.append({"fname": attachment_name, "fcontent": pdf_content})
+
+                except Exception as pdf_error:
+                    frappe.log_error(
+                        title="PDF Generation Error",
+                        message=f"Failed to generate PDF attachment: {str(pdf_error)}\n{traceback.format_exc()}",
+                    )
+                frappe.sendmail(
+                recipients=[preferred_email],
+                subject="Salary Slip",
+                message="Please find attached your salary slip.",
+                attachments=attachments if attachments else None,
+            )
+    except Exception as e:
+        frappe.log_error("Error while sending salary slips", frappe.get_traceback())
+        frappe.throw(_("Error while sending salary slips: {0}").format(str(e)))

--- a/prompt_hr/scheduler_methods.py
+++ b/prompt_hr/scheduler_methods.py
@@ -1276,7 +1276,18 @@ def penalization_for_no_attendance_for_prompt(emp, check_attendance_date, leave_
                                             is_lwp_for_no_attendance=1,
                                             for_no_attendance=1,                                            
                                     )
-            
+            # ? CREATING ATTENDANCE WITH STATUS ABSENT FOR NO ATTENDANCE PENALIZATION
+                att = frappe.get_doc({
+                "doctype": "Attendance",
+                "employee": emp.get("name"),
+                "attendance_date": check_attendance_date,
+                "status": "Absent",
+                "company": emp.get("company"),
+                "docstatus": 0,
+            })
+            att.insert(ignore_permissions=True)
+            att.submit()
+            frappe.db.commit()
             # ? RETURN EMPLOYEE NAME FOR NEXT-DAY PENALIZATION ALERT
             if not (leave_application_exists_next_day or attendance_regularization_exists_next_day or employee_penalty_exists_next_day):
                 employee_scheduled_for_penalty_tomorrow  = emp.get("name")


### PR DESCRIPTION
Added logic in mark_attendance() to identify late entries that fall within the grace period threshold. Introduced a new checkbox field late_entry_within_grace in the Attendance DocType. This field is set only when the in_time exceeds shift start but stays within grace. Enables separation of minor delays from true late comings. Used strict # ? and # ! comment conventions before all logic blocks as per code policy.

(For more info, Check PMS Task: TASK-2025-01120)